### PR TITLE
パンくず上にカレントページがある場合に、リンクではなくなるようになった。

### DIFF
--- a/px-files/php/theme.php
+++ b/px-files/php/theme.php
@@ -417,7 +417,13 @@ class theme{
 		$rtn = '';
 		$rtn .= '<ul>';
 		foreach( $breadcrumb as $pid ){
-			$rtn .= '<li>'.$this->px->mk_link( $pid, array('label'=>$this->px->site()->get_page_info($pid, 'title_breadcrumb'), 'current'=>false) ).'</li>';
+			$rtn .= '<li>';
+			if( $this->px->href($pid) != $this->px->href($this->px->site()->get_current_page_info('id')) ){
+				$rtn .= $this->px->mk_link( $pid, array('label'=>$this->px->site()->get_page_info($pid, 'title_breadcrumb'), 'current'=>false) );
+			}else{
+				$rtn .= '<span>'.htmlspecialchars( $this->px->site()->get_page_info($pid, 'title_breadcrumb') ).'</span>';
+			}
+			$rtn .= '</li>';
 		}
 		$rtn .= '<li><span>'.htmlspecialchars( $this->px->site()->get_current_page_info('title_breadcrumb') ).'</span></li>';
 		$rtn .= '</ul>';

--- a/px-files/sitemaps/sitemap.csv
+++ b/px-files/sitemaps/sitemap.csv
@@ -12,7 +12,8 @@
 "/sample_pages/page2/1-1.html",,,"サンプル2-1-1",,,,,"/sample_pages/page2/>/sample_pages/page2/1.htm",1,,,"sample, サンプル","このページはPxFWのサンプルコードとして予め用意されたものです。サンプルが不要であれば、sample_pagesディレクトリとともに削除してください。",
 "/sample_pages/page2/2.html",,,"サンプル2-2",,,,,"/sample_pages/page2/",1,,,"sample, サンプル","このページはPxFWのサンプルコードとして予め用意されたものです。サンプルが不要であれば、sample_pagesディレクトリとともに削除してください。",
 "/sample_pages/page2/2-1.html",,,"サンプル2-2-1",,,,,"/sample_pages/page2/>/sample_pages/page2/2.html",1,,,"sample, サンプル","このページはPxFWのサンプルコードとして予め用意されたものです。サンプルが不要であれば、sample_pagesディレクトリとともに削除してください。",
-"/sample_pages/page3/",,,"サンプルページ3",,,,,,1,,,"sample, サンプル","このページはPxFWのサンプルコードとして予め用意されたものです。サンプルが不要であれば、sample_pagesディレクトリとともに削除してください。",1
-"/sample_pages/page3/1.html",,,"サンプル3-1",,,,,"/sample_pages/page3/",1,,,"sample, サンプル","このページはPxFWのサンプルコードとして予め用意されたものです。サンプルが不要であれば、sample_pagesディレクトリとともに削除してください。",
-"/sample_pages/page3/2.html",,,"サンプル3-2",,,,,"/sample_pages/page3/",1,,,"sample, サンプル","このページはPxFWのサンプルコードとして予め用意されたものです。サンプルが不要であれば、sample_pagesディレクトリとともに削除してください。",
+"alias:/sample_pages/page3/",,"sample-page-3","サンプルページ3",,,,,,1,,,"sample, サンプル","このページはPxFWのサンプルコードとして予め用意されたものです。サンプルが不要であれば、sample_pagesディレクトリとともに削除してください。",1
+"/sample_pages/page3/",,,"サンプル3-0",,,,,"sample-page-3",1,,,"sample, サンプル","このページはPxFWのサンプルコードとして予め用意されたものです。サンプルが不要であれば、sample_pagesディレクトリとともに削除してください。",
+"/sample_pages/page3/1.html",,,"サンプル3-1",,,,,"sample-page-3",1,,,"sample, サンプル","このページはPxFWのサンプルコードとして予め用意されたものです。サンプルが不要であれば、sample_pagesディレクトリとともに削除してください。",
+"/sample_pages/page3/2.html",,,"サンプル3-2",,,,,"sample-page-3",1,,,"sample, サンプル","このページはPxFWのサンプルコードとして予め用意されたものです。サンプルが不要であれば、sample_pagesディレクトリとともに削除してください。",
 "/sample_pages/help/",,,"ヘルプ",,,,,,1,,,"sample, サンプル","このページはPxFWのサンプルコードとして予め用意されたものです。サンプルが不要であれば、sample_pagesディレクトリとともに削除してください。",

--- a/px-files/themes/pickles2/theme_files/styles/theme.css
+++ b/px-files/themes/pickles2/theme_files/styles/theme.css
@@ -155,9 +155,12 @@ pre code{
 	padding: 0 0.3em 0 0;
 	font-size:small;
 }
-.theme_breadcrumb ul li a:after{
+.theme_breadcrumb ul li:after{
 	content:'>';
 	margin: 0 0.3em;
+}
+.theme_breadcrumb ul li:last-child:after{
+	content:none;
 }
 .theme_breadcrumb ul li span{
 	font-weight:bold;


### PR DESCRIPTION
- alias機能などで、パンくず上にカレントページ(とリンク先が同じページ)が含まれる場合があるのに対応。
